### PR TITLE
refactor(quizzes): implementado deep nested deletion nos quizzes, categorias e alternativas

### DIFF
--- a/src/database/schemas/questionSchema.go
+++ b/src/database/schemas/questionSchema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type Question struct {
@@ -12,7 +13,7 @@ type Question struct {
 	Content   string          `json:"content,omitempty" gorm:"not null"`
 	QuizID    string          `json:"quiz_id,omitempty" gorm:"not null"`
 	Quiz      *Quiz           `json:"quiz,omitempty"`
-	Choices   []Choice        `json:"choices,omitempty" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Choices   []Choice        `json:"choices,omitempty"`
 	CreatedAt *time.Time      `json:"created_at,omitempty"`
 	UpdatedAt *time.Time      `json:"updated_at,omitempty"`
 	DeletedAt *gorm.DeletedAt `json:"deleted_at,omitempty" gorm:"index"`
@@ -22,5 +23,10 @@ func (q *Question) BeforeCreate(tx *gorm.DB) (err error) {
 	if q.ID == "" {
 		q.ID = uuid.New().String()
 	}
+	return
+}
+
+func (q *Question) AfterDelete(tx *gorm.DB) (err error) {
+	tx.Clauses(clause.Returning{}).Where("question_id = ?", q.ID).Delete(&Choice{})
 	return
 }

--- a/src/database/schemas/quizSchema.go
+++ b/src/database/schemas/quizSchema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type Quiz struct {
@@ -14,7 +15,7 @@ type Quiz struct {
 	Category   *Category       `json:"category,omitempty"`
 	CreatedBy  string          `json:"created_by,omitempty"`
 	User       *User           `json:"user,omitempty" gorm:"foreignKey:CreatedBy"`
-	Questions  []Question      `json:"questions,omitempty" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Questions  []Question      `json:"questions,omitempty"`
 	CreatedAt  *time.Time      `json:"created_at,omitempty"`
 	UpdatedAt  *time.Time      `json:"updated_at,omitempty"`
 	DeletedAt  *gorm.DeletedAt `json:"deleted_at,omitempty" gorm:"index"`
@@ -24,5 +25,10 @@ func (q *Quiz) BeforeCreate(tx *gorm.DB) (err error) {
 	if q.ID == "" {
 		q.ID = uuid.New().String()
 	}
+	return
+}
+
+func (q *Quiz) AfterDelete(tx *gorm.DB) (err error) {
+	tx.Clauses(clause.Returning{}).Where("quiz_id = ?", q.ID).Delete(&Question{})
 	return
 }

--- a/src/handlers/quizzesHandlers.go
+++ b/src/handlers/quizzesHandlers.go
@@ -86,6 +86,26 @@ func CreateQuiz(c *gin.Context, db *gorm.DB) {
 		return
 	}
 
+	if _, err := gorm.G[schemas.Category](db).Where("id = ?", categoryUuid).First(c); err != nil {
+		log.Printf("Error fetching category by ID: %v", err)
+
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusBadRequest, types.BadRequestErrorResponseStruct{
+				StatusCode: http.StatusBadRequest,
+				Success:    false,
+				Message:    "Category not found.",
+			})
+			return
+		}
+
+		c.JSON(http.StatusInternalServerError, types.InternalServerErrorResponseStruct{
+			StatusCode: http.StatusInternalServerError,
+			Success:    false,
+			Message:    "An error occurred while verifying the category.",
+		})
+		return
+	}
+
 	userUuid, err := uuid.Parse(c.MustGet("userID").(string))
 	if err != nil {
 		log.Printf("Error parsing User UUID from context: %v", err)

--- a/src/handlers/quizzesHandlers.go
+++ b/src/handlers/quizzesHandlers.go
@@ -440,7 +440,7 @@ func DeleteQuiz(c *gin.Context, db *gorm.DB) {
 		return
 	}
 
-	_, err = gorm.G[schemas.Quiz](db).Where("id = ?", quizUuid).Delete(c)
+	err = db.Where("id = ?", quizUuid.String()).Delete(&schemas.Quiz{ID: quizUuid.String()}).Error
 
 	if err != nil {
 		log.Printf("Error deleting quiz: %v", err)


### PR DESCRIPTION
This pull request introduces improvements to the database schema and handler logic for quizzes and questions. The most significant changes involve refining cascade delete behavior by removing GORM constraints from struct definitions and implementing custom `AfterDelete` hooks to manually handle related record deletions. Additionally, the quiz creation handler now validates the existence of the category before proceeding.

**Database schema and cascade deletion improvements:**

* Removed GORM cascade constraints from the `Choices` field in `Question` and the `Questions` field in `Quiz`, shifting cascade logic from the schema definition to custom hooks. [[1]](diffhunk://#diff-1f21f6457a8c4da1af49295390b559a9a7f756a2846871db31a530bd77b8a84dR8-R16) [[2]](diffhunk://#diff-c550653c1ac3fe9ebf929ade9b827e583eae6acac05d3db2b3b697e0760d2114L17-R18)
* Added `AfterDelete` hooks to `Question` and `Quiz` models to manually delete associated `Choice` and `Question` records, respectively, using GORM clauses. [[1]](diffhunk://#diff-1f21f6457a8c4da1af49295390b559a9a7f756a2846871db31a530bd77b8a84dR28-R32) [[2]](diffhunk://#diff-c550653c1ac3fe9ebf929ade9b827e583eae6acac05d3db2b3b697e0760d2114R30-R34)

**Handler logic enhancements:**

* In the `CreateQuiz` handler (`src/handlers/quizzesHandlers.go`), added a check to verify the category exists before creating a quiz, returning appropriate error responses if not found or if another error occurs.
* Updated the `DeleteQuiz` handler to use a direct GORM delete operation on the `Quiz` model, ensuring the new cascade logic is triggered.